### PR TITLE
Fix bug in Function show instance.

### DIFF
--- a/Control/Enumerable/Functions.hs
+++ b/Control/Enumerable/Functions.hs
@@ -255,6 +255,7 @@ showExpr (CaseE k ps)    = ("case "++var k++" of") : indent sps where
   sps = concat $ zipWith (.++) sbs ses
   
   -- showMatcher (b,e)  = (show b ++ " -> ") .++ showExpr e
+  s .++ []           = s:[] -- for show instances returning empty strings
   s .++ (s2:ss)      = (s++s2) : ss
   
   pad ss = let m = maximum (map length ss) in map (take m . (++ repeat ' ')) ss


### PR DESCRIPTION
When printing a Function that returns a type that has a show instance returning
an empty string (E.G. pretty's Doc type) the program fails with:

```
Control/Enumerable/Functions.hs: Non-exhaustive patterns in function .++
```

This fixes it.  (One can argue that the bug is in the Show instance of the return type)

```
module Main where

import Control.Enumerable
import Control.Enumerable.Values
import Control.Enumerable.Functions

data Example = Zero | One | Two

instance Show Example where
  show Zero = ""   -- sneaky show instance
  show One  = "."
  show Two  = ".."

instance Enumerable (Example) where
  enumerate = datatype [c0 Zero, c0 One, c0 Two]

main = do (mapM_.mapM_) print (values' 3 :: [[Function Int Example]])
```
