### PR TITLE
Update for GHC 8.4

### DIFF
--- a/Control/Enumerable/Count.hs
+++ b/Control/Enumerable/Count.hs
@@ -9,6 +9,7 @@ module Control.Enumerable.Count (
 
 import Control.Enumerable
 import Control.Sized
+import Data.Semigroup
 import Data.Monoid(Monoid(..))
 import Data.List
 import Data.Typeable(Typeable)
@@ -70,6 +71,9 @@ instance Alternative Count where
     zipWithL f (x:xs) (y:ys) = f x y : zipWithL f xs ys
     zipWithL _ [] ys = ys
     zipWithL _ xs [] = xs
+
+instance Semigroup (Count a) where
+  (<>) = (<|>)
 
 instance Monoid (Count a) where
   mempty = empty

--- a/size-based.cabal
+++ b/size-based.cabal
@@ -31,5 +31,7 @@ library
   build-depends:       base >=4.7 && <5,
                        dictionary-sharing >= 0.1 && < 1.0,
                        testing-type-modifiers >= 0.1 && < 1.0,
-                       template-haskell  >=2.5 && <2.13
+                       template-haskell  >=2.5 && <2.14
+  if impl(ghc < 8.0)
+    build-depends: semigroups < 0.19
   default-language:    Haskell2010


### PR DESCRIPTION
Added a `Semigroup` instance and a dependency on the library for GHC < 8.0.