### PR TITLE
Bump template-haskell upper bound

### DIFF
--- a/size-based.cabal
+++ b/size-based.cabal
@@ -31,7 +31,7 @@ library
   build-depends:       base >=4.7 && <5,
                        dictionary-sharing >= 0.1 && < 1.0,
                        testing-type-modifiers >= 0.1 && < 1.0,
-                       template-haskell  >=2.5 && <2.14
+                       template-haskell  >=2.5 && <2.15
   if impl(ghc < 8.0)
     build-depends: semigroups < 0.19
   default-language:    Haskell2010


### PR DESCRIPTION
Allows building with GHC 8.6.

It would be appreciated if you could push a Hackage revision with this change as well.